### PR TITLE
Instance Cache Methods

### DIFF
--- a/backbone.fetch-cache.js
+++ b/backbone.fetch-cache.js
@@ -372,7 +372,7 @@
   Backbone.fetchCache.mixins = {
     cacheSet: function (opts, attr) {
       // Set cache to true so user doesn't have to
-      opts = _.exend({ cache: true }, opts);
+      opts = _.extend({ cache: true }, opts);
 
       return Backbone.fetchCache.setCache(this, opts, attr);
     },

--- a/backbone.fetch-cache.js
+++ b/backbone.fetch-cache.js
@@ -132,6 +132,18 @@
       value: attrs
     };
 
+    instance._fetchCache = {
+      clearItem: function() {
+        Backbone.fetchCache.clearItem(key, opts);
+      },
+      getCacheKey: function() {
+        return Backbone.fetchCache.getCacheKey(instance);
+      },
+      getLastSync: function() {
+        return Backbone.fetchCache.getLastSync(key);
+      }
+    };
+
     Backbone.fetchCache.setLocalStorage();
   }
 

--- a/backbone.fetch-cache.js
+++ b/backbone.fetch-cache.js
@@ -101,6 +101,11 @@
     return url;
   }
 
+  function getCache(key) {
+    if (_.isFunction(key)) { key = key(); }
+    return Backbone.fetchCache._cache[key].value;
+  }
+
   function setCache(instance, opts, attrs) {
     opts = (opts || {});
     var key = Backbone.fetchCache.getCacheKey(instance, opts),
@@ -130,18 +135,6 @@
       lastSync : lastSync,
       prefillExpires: prefillExpires,
       value: attrs
-    };
-
-    instance._fetchCache = {
-      clearItem: function() {
-        Backbone.fetchCache.clearItem(key, opts);
-      },
-      getCacheKey: function() {
-        return Backbone.fetchCache.getCacheKey(instance);
-      },
-      getLastSync: function() {
-        return Backbone.fetchCache.getLastSync(key);
-      }
     };
 
     Backbone.fetchCache.setLocalStorage();
@@ -368,11 +361,34 @@
 
   Backbone.fetchCache._superMethods = superMethods;
   Backbone.fetchCache.setCache = setCache;
+  Backbone.fetchCache.getCache = getCache;
   Backbone.fetchCache.getCacheKey = getCacheKey;
   Backbone.fetchCache.getLastSync = getLastSync;
   Backbone.fetchCache.clearItem = clearItem;
   Backbone.fetchCache.setLocalStorage = setLocalStorage;
   Backbone.fetchCache.getLocalStorage = getLocalStorage;
+
+  // Mixins
+  Backbone.fetchCache.mixins = {
+    cacheSet: function (opts, attr) {
+      // Set cache to true so user doesn't have to
+      opts = _.exend({ cache: true }, opts);
+
+      return Backbone.fetchCache.setCache(this, opts, attr);
+    },
+    cacheGet: function (opts) {
+      var key = Backbone.fetchCache.getCacheKey(this);
+      return Backbone.fetchCache.getCache(key, opts);
+    },
+    cacheClear: function (opts) {
+      var key = Backbone.fetchCache.getCacheKey(this);
+      return Backbone.fetchCache.clearItem(key, opts);
+    },
+    cacheLastSync: function (opts) {
+      var key = Backbone.fetchCache.getCacheKey(this);
+      return Backbone.fetchCache.getLastSync(key, opts);
+    }
+  };
 
   return Backbone;
 }));

--- a/readme.md
+++ b/readme.md
@@ -123,11 +123,21 @@ myCollection.fetch({
 });
 ```
 
-### lastSync
-If you want to know when was the last (server) sync of a given key, you can use:
+### Instance Cache Methods
+Once the cache is set on a model/collection a special `_fetchCache` object is set.
 
 ```js
-Backbone.fetchCache.getLastSync(myKey);
+// Manually clear the cache for an instance
+myModel._fetchCache.clearItem();
+myCollection._fetchCache.clearItem();
+
+// Get the cache key being used for an instance
+myModel._fetchCache.getCacheKey();
+myCollection._fetchCache.getCacheKey();
+
+// Get the last time this instance was synced to the server
+myModel._fetchCache.getLastSync();
+myCollection._fetchCache.getLastSync();
 ```
 
 ### localStorage
@@ -196,13 +206,6 @@ The `sync` event will be triggered on a server response which skips the cache, a
 The cache item for a particular call will be cleared when a `create`, `update`, `patch` or `delete` call is made to the server. The plugin tries to be intelligent about this by clearing a model's collection cache if the model has a `.collection property`.
 
 To achieve this, the plugin overrides `Backbone.Model.protoype.sync` and then calls the original method. If you are planning to override sync on a particular model then you should keep this in mind and make sure that you do it before the plugin runs. Overriding Backbone.sync directly should work fine.
-
-### Manual Cache Invalidation
-Sometimes you just need to clear a cached item manually. This can be called safely from anywhere in your application.
-
-```js
-Backbone.fetchCache.clearItem(myModel.url);
-```
 
 ## Tests
 You can run the tests by cloning the repo, installing the dependencies and

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,34 @@ The cache item for a particular call will be cleared when a `create`, `update`, 
 
 To achieve this, the plugin overrides `Backbone.Model.protoype.sync` and then calls the original method. If you are planning to override sync on a particular model then you should keep this in mind and make sure that you do it before the plugin runs. Overriding Backbone.sync directly should work fine.
 
+### Mixins
+
+The plugin provides a few mixin functions with `Backbone.fetchCache.mixins` to make the caching functionality available on your model and collection instances. These are optional and if you wish to use them you can do so by extending your models/collections slightly differently.
+
+```js
+var MyModel = Backbone.Model.extend(
+  _.extend({}, Backbone.fetchCache.mixins, {
+    
+    /* Your standard model definitions */
+
+  })
+);
+
+var instance = new MyModel({ title: 'Model With Mixins' });
+
+/* Set the cache only - calls Backbone.fetchCache.setCache */
+instance.cacheSet({ expires: 2000 }, { title: 'Title in cache changed' });
+
+// Get the cache value - calls Backbone.fetchCache.getCache
+var cacheValue = instance.cacheGet();
+
+// Get the last sync time - calls Backbone.fetchCache.getLastSync
+instance.cacheLastSync();
+
+// Clear the cache - calls Backbone.fetchCache.clearItem
+instance.cacheClear();
+```
+
 ## Tests
 You can run the tests by cloning the repo, installing the dependencies and
 running `grunt jasmine`:

--- a/spec/backbone.fetch-cache.spec.js
+++ b/spec/backbone.fetch-cache.spec.js
@@ -80,6 +80,31 @@ describe('Backbone.fetchCache', function() {
     });
   });
 
+  describe('Instance cache methods', function() {
+    var lastSync;
+
+    beforeEach(function() {
+      lastSync = (new Date()).getTime();
+      var opts = { cache: true, lastSync: lastSync };
+
+      Backbone.fetchCache.setCache(model, opts, modelResponse);
+    });
+
+    it('clears the cache', function() {
+      model._fetchCache.clearItem();
+
+      expect(Backbone.fetchCache._cache[model._fetchCache.getCacheKey()]).toEqual(null);
+    });
+
+    it('gets the cache key', function() {
+      expect(model._fetchCache.getCacheKey()).toEqual(model.url);
+    });
+
+    it('gets the last sync', function() {
+      expect(model._fetchCache.getLastSync()).toEqual(lastSync);
+    });
+  });
+
   describe('.getCacheKey', function() {
     it('uses options url with priority if set', function() {
       expect(Backbone.fetchCache.getCacheKey(model, {url: '/options-test-url'}))

--- a/spec/backbone.fetch-cache.spec.js
+++ b/spec/backbone.fetch-cache.spec.js
@@ -81,27 +81,43 @@ describe('Backbone.fetchCache', function() {
   });
 
   describe('Instance cache methods', function() {
-    var lastSync;
+    var CacheModel, cacheModelInstance, lastSync, opts;
 
     beforeEach(function() {
-      lastSync = (new Date()).getTime();
-      var opts = { cache: true, lastSync: lastSync };
+      CacheModel = Backbone.Model.extend(
+        _.extend({}, Backbone.fetchCache.mixins, {
+          url: '/cache-model'
+        })
+      );
 
-      Backbone.fetchCache.setCache(model, opts, modelResponse);
+      lastSync = (new Date()).getTime();
+      opts = { cache: true, lastSync: lastSync };
+
+      cacheModelInstance = new CacheModel({ title: 'Cache Model' });
+
+      Backbone.fetchCache.setCache(cacheModelInstance, opts, { title: 'Cache Model' });
+    });
+
+    it('sets the cache', function() {
+      var data = { title: 'My New Cached Title' };
+
+      cacheModelInstance.cacheSet(opts, data);
+
+      expect(Backbone.fetchCache._cache[cacheModelInstance.url].value).toEqual(data);
+    });
+
+    it('gets the cache', function() {
+      expect(cacheModelInstance.cacheGet()).toEqual({ title: 'Cache Model' });
     });
 
     it('clears the cache', function() {
-      model._fetchCache.clearItem();
+      cacheModelInstance.cacheClear();
 
-      expect(Backbone.fetchCache._cache[model._fetchCache.getCacheKey()]).toEqual(null);
-    });
-
-    it('gets the cache key', function() {
-      expect(model._fetchCache.getCacheKey()).toEqual(model.url);
+      expect(Backbone.fetchCache._cache[cacheModelInstance.url]).toEqual(null);
     });
 
     it('gets the last sync', function() {
-      expect(model._fetchCache.getLastSync()).toEqual(lastSync);
+      expect(cacheModelInstance.cacheLastSync()).toEqual(lastSync);
     });
   });
 


### PR DESCRIPTION
When the cache is set it assigns a special `_fetchCache` object of convenience methods to perform actions on that instance's cache. This makes it easier to perform cache operations on instances without having to know the key or passing instances to global methods.
